### PR TITLE
feat: add debug flag to helper script

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -1,0 +1,5 @@
+# Developer Notes
+
+## Debug flag
+
+Run `./helper.sh -d` or `./helper.sh --debug` to enable debug mode. This exports `DEBUG=1`, sets `PS4='+ $0:$LINENO '` and enables shell tracing with `set -x` so each sourced script prints commands with file paths. When enabled, the `run` helper also prints the function it executes and skips clearing the screen.

--- a/helper.sh
+++ b/helper.sh
@@ -1,7 +1,23 @@
 #!/bin/sh
 
 set -e
-clear
+
+# Parse arguments
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -d|--debug)
+      export DEBUG=1
+      ;;
+  esac
+  shift
+done
+
+if [ -n "$DEBUG" ]; then
+  export PS4='+ $0:$LINENO '
+  set -x
+else
+  clear
+fi
 
 HELPER_SCRIPT_FOLDER="$(dirname "$(readlink -f "$0")")"
 for script in "${HELPER_SCRIPT_FOLDER}/scripts/"*.sh; do . "${script}"; done

--- a/scripts/menu/functions.sh
+++ b/scripts/menu/functions.sh
@@ -124,7 +124,11 @@ function error_msg() {
 }
 
 function run() {
-  clear
+  if [ -n "$DEBUG" ]; then
+    echo "Running $1"
+  else
+    clear
+  fi
   # $1 - Action performed
   $1
   # $2 - Menu launched after action is completed


### PR DESCRIPTION
## Summary
- add `-d/--debug` flag to enable shell tracing
- skip menu clears and print functions when DEBUG is set
- document debug usage for developers

## Testing
- `bash -n helper.sh`
- `bash -n scripts/menu/functions.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a703492fd083219403f1deb3c8a065